### PR TITLE
Update VSCode extension links to current IDs

### DIFF
--- a/index.html
+++ b/index.html
@@ -110,8 +110,8 @@
           <h3 class="tools-subtitle" data-i18n="tools.vscode.title">VSCode Extension</h3>
           <p class="tools-description" data-i18n="tools.vscode.desc">For the best development experience, use our VSCode extension with full IDE features.</p>
           <div class="tools-buttons">
-            <a href="https://marketplace.visualstudio.com/items?itemName=OpenBlink.open-blink-vscode-extension" class="btn btn-primary" data-i18n="tools.vscode.marketplace">VS Code Marketplace</a>
-            <a href="https://open-vsx.org/extension/openblink/open-blink-vscode-extension" class="btn btn-secondary" data-i18n="tools.vscode.openvsx">OpenVSX</a>
+            <a href="https://marketplace.visualstudio.com/items?itemName=OpenBlink.openblink-extension" class="btn btn-primary" data-i18n="tools.vscode.marketplace">VS Code Marketplace</a>
+            <a href="https://open-vsx.org/extension/openblink/openblink-extension" class="btn btn-secondary" data-i18n="tools.vscode.openvsx">OpenVSX</a>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- Replace VS Code Marketplace link with `OpenBlink.openblink-extension`
- Replace OpenVSX link with `openblink/openblink-extension`
- Remove temporary local note file from this change set

## Test plan
- [x] Confirm `index.html` contains updated Marketplace URL
- [x] Confirm `index.html` contains updated OpenVSX URL
- [x] Verify no extra files included in commit

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/openblink/www.openblink.org/pull/17" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
