### PR TITLE
Fix missing version-panel for WebIDE 0.3.5

### DIFF
--- a/index.html
+++ b/index.html
@@ -132,14 +132,19 @@
                 <p data-i18n="tools.webide.canary.desc">Latest experimental features. May be unstable.</p>
                 <a href="tools/canary/webide/index.html" class="btn btn-primary" data-i18n="tools.webide.launch">Launch WebIDE</a>
               </div>
-              <div class="version-panel" id="panel-0.3.4">
-                <h4 data-i18n="tools.webide.stable.title">Version 0.3.4</h4>
+              <div class="version-panel" id="panel-0.3.5">
+                <h4 data-i18n="tools.webide.stable.title">Version 0.3.5</h4>
                 <p data-i18n="tools.webide.stable.desc">Current stable release with WebSimulator support.</p>
+                <a href="tools/0.3.5/webide/index.html" class="btn btn-primary" data-i18n="tools.webide.launch">Launch WebIDE</a>
+              </div>
+              <div class="version-panel" id="panel-0.3.4">
+                <h4 data-i18n="tools.webide.legacy.title">Version 0.3.4</h4>
+                <p data-i18n="tools.webide.legacy.desc">Previous stable release for backwards compatibility.</p>
                 <a href="tools/0.3.4/webide/index.html" class="btn btn-primary" data-i18n="tools.webide.launch">Launch WebIDE</a>
               </div>
               <div class="version-panel" id="panel-0.3.3">
                 <h4 data-i18n="tools.webide.legacy.title">Version 0.3.3</h4>
-                <p data-i18n="tools.webide.legacy.desc">Previous stable release for backwards compatibility.</p>
+                <p data-i18n="tools.webide.legacy.desc">Older stable release for backwards compatibility.</p>
                 <a href="tools/0.3.3/webide/index.html" class="btn btn-primary" data-i18n="tools.webide.launch">Launch WebIDE</a>
               </div>
             </div>


### PR DESCRIPTION
## Summary

This PR fixes a critical bug in the WebIDE version selector where clicking the 0.3.5 tab would not display the corresponding panel, breaking the version selector functionality.

## Root Cause

The previous PR (#19) added the 0.3.5 version-tab but failed to add the corresponding version-panel, causing the version selector to malfunction.

## Changes

- **Add panel-0.3.5**: Added the missing version panel for 0.3.5 with stable title/description and correct link (tools/0.3.5/webide/index.html)
- **Update panel-0.3.4**: Changed 0.3.4 panel from stable to legacy category (updated i18n keys from stable to legacy)
- **Align tabs and panels**: Ensured version-tabs and version-panels are properly aligned

## Testing

- Verified that clicking each version tab now displays the correct panel
- Confirmed that 0.3.5 links to the correct directory (tools/0.3.5/webide/index.html)
- Checked that 0.3.4 and 0.3.3 display legacy titles and descriptions

## Related Issues

Fixes the bug introduced in #19